### PR TITLE
Add startup script for .NET 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,15 @@ Die Projektstruktur mit BLL, DAL und UI ist angelegt, enthält jedoch überwiege
 1. Visual Studio oeffnen: `start Arbeitszeiterfassung.sln`
 2. Schritt 1.2 ausfuehren (Datenbankdesign)
 3. Prompt verwenden: `..\Prompts\Schritt_1_2_Datenbankdesign.md`
+
+## Codex Setup Script
+
+Um sicherzustellen, dass das .NET 8 SDK in jeder Codex-Session verfügbar ist, gibt es das Skript `setup.sh` im Projektstamm. Dieses installiert das SDK automatisch, falls es noch nicht vorhanden ist.
+
+Öffne in deinen Codex-Projekt-Einstellungen den Bereich **Setup Commands** und trage dort den folgenden Befehl ein. Dadurch startet das Skript automatisch zu Beginn jeder Session:
+
+```bash
+bash setup.sh
+```
+
+Danach steht `dotnet` mit Version 8 automatisch zur Verfügung.

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# ---
+# title: Codex Start Setup
+# description: Installs .NET 8 SDK on container start
+# ---
+set -e
+
+# Check if .NET 8 SDK already installed
+if dotnet --list-sdks 2>/dev/null | grep -q '^8\.0'; then
+    echo ".NET 8 SDK already installed"
+else
+    echo "Installing .NET 8 SDK..."
+    sudo apt-get update
+    sudo apt-get install -y dotnet-sdk-8.0
+fi
+
+echo "dotnet version: $(dotnet --version)"


### PR DESCRIPTION
## Summary
- create `setup.sh` to install .NET 8 SDK if missing
- document automatic setup in README
- clarify how to add the script to Codex Setup Commands

## Testing
- `bash meta/test-projekt.sh` *(fails: project not initialized)*
- `bash setup.sh`


------
https://chatgpt.com/codex/tasks/task_b_685936d86c508322810f33315695f7be