### PR TITLE
Update prompts for DB resources

### DIFF
--- a/meta/Prompts/Schritt_1_1_Projekt_Setup.md
+++ b/meta/Prompts/Schritt_1_1_Projekt_Setup.md
@@ -62,8 +62,8 @@ Arbeitszeiterfassung/
    - Newtonsoft.Json
 4. Erstelle eine Basis-App.config mit Platzhaltern für Connection Strings
 5. Implementiere die Program.cs mit grundlegender Fehlerbehandlung
-6. Erstelle ein leeres MainForm mit Platzhalter für ein Logo
-7. Plane, Logo und Standortdaten bei Programmstart aus der Datenbank zu laden
+6. Erstelle ein leeres MainForm mit Platzhalter für das Unternehmenslogo (Laden aus der Datenbank)
+7. Speichere Logo und Standortdaten in der Datenbank und lade sie beim Programmstart
 
 ## Benötigte Dateien
 Keine - dies ist der erste Schritt
@@ -74,7 +74,7 @@ Keine - dies ist der erste Schritt
 - Program.cs mit Basis-Implementation
 - MainForm (cs, Designer.cs, resx) mit Grundstruktur
 - App.config mit Connection String Templates
-- Standortdaten werden in der Datenbank gehalten; kein standorte.json mehr
+- Standort- und Logodaten werden in der Datenbank gehalten; keine standorte.json oder lokale Logodatei mehr
 
 ## Hinweise
 - Verwende durchgehend deutsche Kommentare

--- a/meta/Prompts/Schritt_1_2_Datenbankdesign.md
+++ b/meta/Prompts/Schritt_1_2_Datenbankdesign.md
@@ -53,19 +53,26 @@ Erstelle die kompletten Entity Framework Core Modelle für die Arbeitszeiterfass
 - Key-Value Store für Konfiguration
 - Typisierte Werte (string, number, boolean, json)
 
+### 9. AppRessource.cs
+- Id (int, Primary Key)
+- Bezeichnung (nvarchar)
+- Daten (BLOB)
+- LetzteAktualisierung (datetime)
+- Wird für Unternehmenslogo und weitere App-Ressourcen verwendet
+
 ## Zusätzlich zu erstellen
 
-### 9. ApplicationDbContext.cs
+### 10. ApplicationDbContext.cs
 - DbContext für MySQL/MariaDB
 - Fluent API Konfiguration
 - Seed-Daten für Rollen
 
-### 10. OfflineDbContext.cs  
+### 11. OfflineDbContext.cs
 - DbContext für SQLite
 - Identische Struktur wie ApplicationDbContext
 - Angepasste Konfiguration für SQLite
 
-### 11. Enums/
+### 12. Enums/
 - Berechtigungsstufe.cs
 - AenderungsAktion.cs
 - AenderungsGrund.cs

--- a/meta/Prompts/Schritt_1_3_Konfigurationsmanagement.md
+++ b/meta/Prompts/Schritt_1_3_Konfigurationsmanagement.md
@@ -28,19 +28,28 @@ Erstelle das vollständige Konfigurationsmanagement für die Arbeitszeiterfassun
 </configuration>
 ```
 
+
 ### 2. Tabelle "Standorte"
 Alle Standorte werden in einer Datenbanktabelle gepflegt:
 - Standortdefinitionen inkl. IP-Range Mappings
 - Home-Office Einstellungen
 - VPN-Konfiguration
 
-### 3. ConfigurationManager.cs
+### 3. Tabelle "AppRessourcen" (Logo)
+Das Unternehmenslogo wird nicht mehr im Ressourcenordner abgelegt, sondern in einer eigenen Datenbanktabelle gespeichert.
+- Id (int, Primary Key)
+- Bezeichnung (nvarchar)
+- Daten (BLOB)
+- LetzteAktualisierung (datetime)
+Die Anwendung lädt das Logo beim Start aus dieser Tabelle.
+
+### 4. ConfigurationManager.cs
 - Zentrale Konfigurationsverwaltung
 - Strongly-typed Settings
 - Hot-Reload Funktionalität
 - Verschlüsselung sensibler Daten
 
-### 4. AppSettings.cs
+### 5. AppSettings.cs
 ```csharp
 public class AppSettings
 {
@@ -52,12 +61,12 @@ public class AppSettings
 }
 ```
 
-### 5. EncryptionHelper.cs
+### 6. EncryptionHelper.cs
 - Connection String Verschlüsselung
 - API-Key Schutz
 - Sichere Speicherung mit DPAPI
 
-### 6. ConfigValidator.cs
+### 7. ConfigValidator.cs
 - Konfigurationsprüfung beim Start
 - Pflichtfelder-Validierung
 - IP-Range Format-Checks

--- a/meta/Prompts/Schritt_4_1_Hauptfenster.md
+++ b/meta/Prompts/Schritt_4_1_Hauptfenster.md
@@ -10,14 +10,14 @@ category: Entwicklung
 # Prompt für Schritt 4.1: Hauptfenster und Navigation
 
 ## Aufgabe
-Erstelle das Hauptfenster (MainForm) der Arbeitszeiterfassungsanwendung mit MP-Logo, Navigation und Grundlayout.
+Erstelle das Hauptfenster (MainForm) der Arbeitszeiterfassungsanwendung mit MP-Logo, Navigation und Grundlayout. Das Logo wird beim Start aus der Datenbank geladen.
 
 ## UI-Komponenten
 
 ### 1. MainForm Design
 - **Fenster-Eigenschaften**:
   - Titel: "Arbeitszeiterfassung - [Benutzername]"
-  - Icon: MP-Logo
+  - Icon: MP-Logo (aus der Datenbank geladen)
   - Größe: 1024x768 (resizable)
   - MinimumSize: 800x600
   - StartPosition: CenterScreen
@@ -25,7 +25,7 @@ Erstelle das Hauptfenster (MainForm) der Arbeitszeiterfassungsanwendung mit MP-L
 ### 2. Layout-Struktur
 ```
 ┌─────────────────────────────────────────┐
-│ MP-Logo │ Arbeitszeiterfassung         │ (TitleBar)
+│ MP-Logo │ Arbeitszeiterfassung         │ (TitleBar, Logo aus DB)
 ├─────────────────────────────────────────┤
 │ Benutzer: [Name] ([Rolle])    [Status] │ (StatusBar)
 ├─────────────────────────────────────────┤
@@ -80,7 +80,7 @@ Erstelle das Hauptfenster (MainForm) der Arbeitszeiterfassungsanwendung mit MP-L
 - Material Design Icons
 - 24x24 für Toolbar
 - 16x16 für Buttons
-- MP-Logo: 48x48
+- MP-Logo: 48x48 (aus der Datenbank geladen)
 
 ### 5. Controls und Events
 
@@ -114,7 +114,7 @@ Erstelle das Hauptfenster (MainForm) der Arbeitszeiterfassungsanwendung mit MP-L
 ## Benötigte Dateien
 - AuthenticationService aus Schritt 3.1
 - SessionManager
-- MP-Logo Datei
+- MP-Logo aus Datenbank
 
 ## Erwartete Ausgabe
 ```


### PR DESCRIPTION
## Summary
- erweitere das Datenbankdesign um eine Tabelle `AppRessource`
- verdeutliche im Projekt-Setup, dass Logo und Standorte aus der DB geladen werden
- dokumentiere in der Konfigurationsanleitung die neue Tabelle
- Hauptfenster-Prompt beschreibt das Laden des Logos aus der DB

## Testing
- `bash meta/test-projekt.sh` *(fails: Hauptverzeichnis fehlt)*

------
https://chatgpt.com/codex/tasks/task_b_685a934e89108322b92dd63ecb73a9de