### PR TITLE
Update docs for user confirmation rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,4 +40,8 @@ Danach steht `dotnet` mit Version 8 automatisch zur Verfügung.
 
 Um das Projekt unter Windows zu bauen und die Unit-Tests auszuführen, kann das Skript `build-windows.cmd` genutzt werden. Es installiert die erforderliche Windows-Desktop-Workload und führt anschliessend `dotnet build` sowie `dotnet test` aus. Die Konsolenausgabe des Skripts kann zur Validierung an mich zurückgegeben werden.
 
+## Schrittabschluss
+
+Ein Schritt gilt erst als vollendet, wenn der Benutzer die entsprechenden Änderungen auf seinem Zielsystem getestet und positiv bestätigt hat. Solange diese Rückmeldung fehlt, wird der Schritt nicht als abgeschlossen markiert.
+
 Antworte immer auf deutsch!

--- a/meta/README.md
+++ b/meta/README.md
@@ -165,6 +165,7 @@ Das Projekt folgt einem strukturierten 19-Schritte-Plan:
 - **Code-Stil**: C# Coding Conventions
 - **Commits**: Konventionelle Commit-Messages
 - **Tests**: Mindestens 80% Code Coverage
+- **Schrittabschluss**: Ein Entwicklungsschritt wird erst nach positiver Rückmeldung des Benutzers über erfolgreiche Tests als erledigt markiert.
 
 ## 🔒 Sicherheit & Compliance
 

--- a/meta/ZENTRALE_ANWEISUNGSDATEI.md
+++ b/meta/ZENTRALE_ANWEISUNGSDATEI.md
@@ -119,6 +119,7 @@ ls -la
 2. **Bei Code-Änderungen**: Kommentare aktualisieren
 3. **Nach Feature-Completion**: Dokumentation updaten (auch die ZENTRALE_ANWEISUNGSDATEI.md)
 4. **Vor Schritt-Abschluss**: Code-Review durchführen
+5. **Benutzerbestätigung**: Ein Schritt gilt erst nach positiver Rückmeldung des Benutzers über erfolgreiche Tests auf dem Zielsystem als abgeschlossen.
 
 ## Hilfreiche Referenzen
 


### PR DESCRIPTION
## Summary
- reinforce that every step needs user confirmation before being closed
- document the rule in `README.md`, `meta/README.md`, and the central instructions

## Testing
- `bash meta/test-projekt.sh` *(fails: 3 tests)*

------
https://chatgpt.com/codex/tasks/task_b_686b8995247483229a5e5b96c4fddca5