### PR TITLE
Fix missing BLL references

### DIFF
--- a/Arbeitszeiterfassung.BLL/Interfaces/IArbeitszeitCalculator.cs
+++ b/Arbeitszeiterfassung.BLL/Interfaces/IArbeitszeitCalculator.cs
@@ -9,6 +9,7 @@ Beschreibung: Schnittstelle fuer Berechnungen der Arbeitszeit
 */
 
 using Arbeitszeiterfassung.DAL.Models;
+using Arbeitszeiterfassung.BLL.Models;
 
 namespace Arbeitszeiterfassung.BLL.Interfaces;
 

--- a/Arbeitszeiterfassung.BLL/Interfaces/IArbeitszeitValidator.cs
+++ b/Arbeitszeiterfassung.BLL/Interfaces/IArbeitszeitValidator.cs
@@ -9,6 +9,7 @@ Beschreibung: Schnittstelle fuer Validierungslogik der Zeiterfassung
 */
 
 using Arbeitszeiterfassung.DAL.Models;
+using Arbeitszeiterfassung.BLL.Models;
 
 namespace Arbeitszeiterfassung.BLL.Interfaces;
 

--- a/Arbeitszeiterfassung.BLL/Interfaces/IZeiterfassungService.cs
+++ b/Arbeitszeiterfassung.BLL/Interfaces/IZeiterfassungService.cs
@@ -9,6 +9,7 @@ Beschreibung: Schnittstelle fuer die Zeiterfassungslogik
 */
 
 using Arbeitszeiterfassung.DAL.Models;
+using Arbeitszeiterfassung.BLL.Models;
 
 namespace Arbeitszeiterfassung.BLL.Interfaces;
 

--- a/Arbeitszeiterfassung.BLL/Services/ZeiterfassungService.cs
+++ b/Arbeitszeiterfassung.BLL/Services/ZeiterfassungService.cs
@@ -13,7 +13,7 @@ using Arbeitszeiterfassung.BLL.Events;
 using Arbeitszeiterfassung.BLL.Helpers;
 using Arbeitszeiterfassung.BLL.Models;
 using Arbeitszeiterfassung.DAL.Models;
-using Arbeitszeiterfassung.DAL.UnitOfWork;
+using Arbeitszeiterfassung.DAL.Interfaces;
 using System.Linq;
 
 namespace Arbeitszeiterfassung.BLL.Services;


### PR DESCRIPTION
## Summary
- add required BLL model namespace to several interfaces
- use DAL.Interfaces namespace in `ZeiterfassungService`

## Testing
- `dotnet build Arbeitszeiterfassung.BLL/Arbeitszeiterfassung.BLL.csproj`
- `dotnet test Arbeitszeiterfassung.Tests/Arbeitszeiterfassung.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_b_686b9c74d4ec83229f965dec842b791c