### PR TITLE
Dokumentation erweitert: Testskripte und Schrittabschluss

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ bash setup.sh
 
 Danach steht `dotnet` mit Version 8 automatisch zur Verfügung.
 
-Um das Projekt unter Windows zu bauen und die Unit-Tests auszuführen, kann das Skript `build-windows.cmd` genutzt werden. Es installiert die erforderliche Windows-Desktop-Workload und führt anschliessend `dotnet build` sowie `dotnet test` aus. Die Konsolenausgabe des Skripts kann zur Validierung an mich zurückgegeben werden.
+Um das Projekt unter Windows zu bauen und die Unit-Tests auszuführen, kann das Skript `build-windows.cmd` genutzt werden. Es installiert die erforderliche Windows-Desktop-Workload und führt anschließend `dotnet build` sowie `dotnet test` aus.
+
+Für Linux/WSL-Systeme steht das Prüfskript `meta/test-projekt.sh` bereit. Dieses überprüft die Projektstruktur, führt einen Build aus und liefert eine Zusammenfassung der Testergebnisse. Bitte sende mir die Konsolenausgabe eines dieser Skripte als Bestätigung der erfolgreichen Tests auf deinem Zielsystem.
 
 ## Testergebnisse
 

--- a/meta/QUICK_START.md
+++ b/meta/QUICK_START.md
@@ -38,6 +38,7 @@ Der Prompt dafür ist in: Prompts/Schritt_1_1_Projekt_Setup.md
 - [ ] Aktuellen Schritt identifiziert
 - [ ] Entsprechenden Prompt geöffnet
 - [ ] Entwicklungsumgebung bereit
+- [ ] `meta/test-projekt.sh` auf dem Zielsystem ausgeführt und Ergebnis notiert
 
 ## 🎯 Direkt-Prompts für häufige Aufgaben
 
@@ -107,5 +108,9 @@ cat /app/AZE/Arbeitsplan_Arbeitszeiterfassung.md
 # Bewertung lesen:
 cat /app/AZE/Arbeitsplan_Bewertung.md
 ```
+
+## Schrittabschluss
+
+Ein Entwicklungsschritt gilt erst als abgeschlossen, wenn er auf deinem Zielsystem erfolgreich getestet wurde. Führe dazu `meta/test-projekt.sh` (Linux/WSL) oder `build-windows.cmd` (Windows) aus und sende mir die Konsolenausgabe als Bestätigung.
 
 **Tipp**: Beginne immer mit dem Lesen der ZENTRALE_ANWEISUNGSDATEI.md!


### PR DESCRIPTION
## Summary
- erweitere README mit Hinweis auf `meta/test-projekt.sh`
- ergänze Quick Start um Testskript und Hinweis zum Schrittabschluss

## Testing
- `bash setup.sh`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_b_686ce8034ab88322a3b373d1a6480f06